### PR TITLE
No-arrow / rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Run the application using Java and the executable JAR file produced by the Gradl
 listening to port `8080`.
 
 ```console
-$ java -jar build/libs/joi-energy.jar
+$ java -jar build/libs/developer-joyofenergy-kotlin.jar
 ```
 
 ### Run the tests

--- a/build.gradle
+++ b/build.gradle
@@ -38,9 +38,6 @@ dependencies {
     implementation "io.ktor:ktor-server-core:$ktor_version"
     implementation "io.ktor:ktor-jackson:$ktor_version"
 
-    implementation "io.arrow-kt:arrow-core:$arrow_version"
-    implementation "io.arrow-kt:arrow-fx:$arrow_version"
-
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jackson_version"
 
     testImplementation "io.ktor:ktor-server-tests:$ktor_version"

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,5 @@ logback_version=1.2.1
 ktor_version=1.3.0
 kotlin.code.style=official
 kotlin_version=1.3.61
-arrow_version =0.10.4
 strikt_version=0.22.2
 jackson_version=2.10.2

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = "joi-energy-kotlin"
+rootProject.name = "developer-joyofenergy-kotlin"


### PR DESCRIPTION
Removes arrow dependency as not required or used.

Changes of build to reflect the name of the project and be more in line with the other languages.