### PR TITLE
Maintainer tasks

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     kotlin("jvm")
     id("io.ktor.plugin")
     id("io.gitlab.arturbosch.detekt")
+    id("com.github.ben-manes.versions")
 }
 
 val kotlin_version: String by project

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,7 @@
-logback_version=1.4.8
-ktor_version=2.3.2
-kotlin_version=1.9.0
-strikt_version=0.34.1
-jackson_version=2.15.2
 detekt_version=1.23.0
+jackson_version=2.15.2
+kotlin_version=1.9.0
+ktor_version=2.3.2
+logback_version=1.4.8
+strikt_version=0.34.1
+versions_version=0.46.0

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,10 +2,12 @@ pluginManagement {
     val kotlin_version: String by settings
     val ktor_version: String by settings
     val detekt_version: String by settings
+    val versions_version: String by settings
     plugins {
         kotlin("jvm") version kotlin_version
         id("io.ktor.plugin") version ktor_version
         id("io.gitlab.arturbosch.detekt") version detekt_version
+        id("com.github.ben-manes.versions") version versions_version
     }
 }
 


### PR DESCRIPTION
Add the "versions" plugin to help maintainers keep the repo dependencies up to date.

Also ... alphabetize `gradle.properties`